### PR TITLE
FIX: Return a non-empty address

### DIFF
--- a/compress-roas
+++ b/compress-roas
@@ -54,11 +54,11 @@ def prefix_to_key(prefix):
     if prefix.version == 4:
         address = prefix.ip.bits().replace(".","")
         l = int(prefix.cidr.hostmask.bin, 2).bit_length()
-        return str(prefix.version) + "$" + address[:-l]
+        return str(prefix.version) + "$" + (address[:-l] if l > 0 else address)
     elif prefix.version == 6:
         address = prefix.ip.bits().replace(":","")
         l = int(prefix.cidr.hostmask.bin, 2).bit_length()
-        return str(prefix.version) + "$" + address[:-l]
+        return str(prefix.version) + "$" + (address[:-l] if l > 0 else address)
     else:
         raise RuntimeError("invalid address version " + str(prefix.version))
 


### PR DESCRIPTION
There's a mistake in `prefix_to_key` function.

When prefix length is equal to 32, the code will produce an empty string for `address[:-l]`.

That's because `l` may equal to 0, in which situation `address[:0]` is an empty string.